### PR TITLE
Install qemu-kvm to provide qemu-img binary

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -9,4 +9,4 @@ apt-get update
 apt-get install build-essential libsqlite3-dev curl rsync git-core \
   libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev \
   genisoimage mkpasswd \
-  debootstrap kpartx -y
+  debootstrap kpartx qemu-kvm -y


### PR DESCRIPTION
Deploying on OpenStack seemed to result in an Inception VM with no qemu-img binary installed. Adding this package should remedy this.
