### PR TITLE
Manually install httparty to resolve #57 [gem install bosh_deployer fails with: aws-sdk requires httparty (~> 0.7) ]

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_bosh
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_bosh
@@ -44,7 +44,9 @@ if [[ "${INSTALL_BOSH_FROM_SOURCE}X" != "X" ]]; then
 
 else
   install_gem bosh_cli
+  # TODO remove this when bosh_deployer starts installing aws-sdk 1.8.1.1 or higher
   install_gem httparty
+  # end TODO
   install_gem bosh_deployer
 fi
 


### PR DESCRIPTION
Whilst we wait for https://github.com/cloudfoundry/bosh/pull/19 to get merged
