### PR TITLE
Inception preparation now setups up git config for user

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Next
+
+* For existing users: please run "deploy --upgrade-deps" as new inception package (runit) added
+
 ## v0.6
 
 Highlights:

--- a/lib/bosh-bootstrap/cli.rb
+++ b/lib/bosh-bootstrap/cli.rb
@@ -327,6 +327,10 @@ module Bosh::Bootstrap
       def load_deploy_options
         settings["fog_path"] = File.expand_path(options[:fog] || "~/.fog")
 
+        settings["git"] ||= {}
+        settings["git"]["name"] ||= `git config user.name`.strip
+        settings["git"]["email"] ||= `git config user.email`.strip
+
         settings["bosh_git_source"] = options[:"edge-deployer"] # use bosh git repo instead of rubygems
 
         # determine which micro-bosh stemcell to download/create

--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/configure_git
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/configure_git
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Setup git configuration for the user
+#
+# Run as the user to configure
+#
+# Requires:
+# * $GIT_USER_NAME
+# * $GIT_USER_EMAIL
+
+if [[ $EUID -ne 0 ]]; then
+  echo "ERROR: This script must be run as root" 1>&2
+  exit 1
+fi
+
+if [[ "${GIT_USER_NAME}X" == "X" ]]; then
+  echo 'ERROR please provide $GIT_USER_NAME'
+  exit 1
+fi
+if [[ "${GIT_USER_EMAIL}X" == "X" ]]; then
+  echo 'ERROR please provide $GIT_USER_EMAIL'
+  exit 1
+fi
+
+cd ~vcap
+chpst -u vcap:vcap git config -f ~vcap/.gitconfig user.name "${GIT_USER_NAME}"
+chpst -u vcap:vcap git config -f ~vcap/.gitconfig user.email "${GIT_USER_EMAIL}"

--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -8,6 +8,7 @@ fi
 apt-get update
 apt-get install build-essential libsqlite3-dev curl rsync git-core tmux \
   libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev \
+  runit \
   genisoimage mkpasswd \
   debootstrap kpartx qemu-kvm \
   vim -y

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -56,6 +56,8 @@ describe Bosh::Bootstrap do
 
     it "stage 4 - prepare inception VM" do
       testing_stage(4)
+      setting "git.name", "Dr Nic Williams"
+      setting "git.email", "drnicwilliams@gmail.com"
       setting "inception.username", "ubuntu"
       setting "bosh.password", "UNSALTED"
       @cmd.should_receive(:run_server).and_return(true)


### PR DESCRIPTION
Also installs runit to get the chpst command.
NOTE: Users must upgrade their inception VM:

```
bosh-bootstrap deploy --upgrade-deps
```

@mrdavidlaing @frodenas can you please review

I do also want to move `deploy --upgrade-deps` into its own CLI command: `upgrade-inception`.
