### PR TITLE
mosh cmd did not open necessary ports

### DIFF
--- a/lib/bosh/providers/aws.rb
+++ b/lib/bosh/providers/aws.rb
@@ -70,11 +70,13 @@ class Bosh::Providers::AWS < Bosh::Providers::BaseProvider
   #   ssh: 22,
   #   http: { ports: (80..82) },
   #   mosh: { protocol: "udp", ports: (60000..60050) }
+  #   mosh: { protocol: "rdp", ports: (3398..3398), ip_ranges: [ { cidrIp: "196.212.12.34/32" } ] }
   # }
   # In this example, 
-  #  * TCP 22 will be opened for ssh, 
-  #  * TCP ports 80, 81, 82 for http and
-  #  * UDP 60000 -> 60050 for mosh
+  #  * TCP 22 will be opened for ssh from any ip_range,
+  #  * TCP ports 80, 81, 82 for http from any ip_range,
+  #  * UDP 60000 -> 60050 for mosh from any ip_range and
+  #  * TCP 3398 for RDP from ip range: 96.212.12.34/32
   def create_security_group(security_group_name, description, ports)
     unless sg = fog_compute.security_groups.get(security_group_name)
       sg = fog_compute.security_groups.create(name: security_group_name, description: description)
@@ -85,10 +87,10 @@ class Bosh::Providers::AWS < Bosh::Providers::BaseProvider
     ip_permissions = sg.ip_permissions
     ports_opened = 0
     ports.each do |name, port_defn|
-      (protocol, port_range) = extract_port_definition(port_defn)
-      unless port_open?(ip_permissions, port_range, protocol)
-        sg.authorize_port_range(port_range, {:ip_protocol => protocol})
-        puts " -> opened #{name} ports #{protocol.upcase} #{port_range.min}..#{port_range.max}"
+      (protocol, port_range, ip_range) = extract_port_definition(port_defn)
+      unless port_open?(ip_permissions, port_range, protocol, ip_range)
+        sg.authorize_port_range(port_range, {:ip_protocol => protocol, :cidr_ip => ip_range})
+        puts " -> opened #{name} ports #{protocol.upcase} #{port_range.min}..#{port_range.max} from IP range #{ip_range}"
         ports_opened += 1
       end   
     end
@@ -101,28 +103,32 @@ class Bosh::Providers::AWS < Bosh::Providers::BaseProvider
   #   ssh: 22,
   #   http: { ports: (80..82) },
   #   mosh: { protocol: "udp", ports: (60000..60050) }
+  #   mosh: { protocol: "rdp", ports: (3398..3398), ip_range: "196.212.12.34/32" }
   # }
   # In this example, 
-  #  * TCP 22 will be opened for ssh, 
-  #  * TCP ports 80, 81, 82 for http and
-  #  * UDP 60000 -> 60050 for mosh
+  #  * TCP 22 will be opened for ssh from any ip_range,
+  #  * TCP ports 80, 81, 82 for http from any ip_range,
+  #  * UDP 60000 -> 60050 for mosh from any ip_range and
+  #  * TCP 3398 for RDP from ip range: 96.212.12.34/32
   def extract_port_definition(port_defn)
+    protocol = "tcp"
+    ip_range = "0.0.0.0/0"
     if port_defn.is_a? Integer
-      protocol = "tcp"
       port_range = (port_defn..port_defn)
     elsif port_defn.is_a? Range
-      protocol = "tcp"
       port_range = port_defn
     elsif port_defn.is_a? Hash
-      protocol = port_defn[:protocol]
-      port_range = port_defn[:ports]
+      protocol = port_defn[:protocol] if port_defn[:protocol]
+      port_range = port_defn[:ports]  if port_defn[:ports]
+      ip_range = port_defn[:ip_range] if port_defn[:ip_range]
     end
-    [protocol, port_range]
+    [protocol, port_range, ip_range]
   end
 
-  def port_open?(ip_permissions, port_range, protocol)
+  def port_open?(ip_permissions, port_range, protocol, ip_range)
     ip_permissions && ip_permissions.find do |ip| 
       ip["ipProtocol"] == protocol \
+      && ip["ipRanges"].detect { |range| range["cidrIp"] == ip_range } \
       && ip["fromPort"] <= port_range.min \
       && ip["toPort"] >= port_range.max 
     end


### PR DESCRIPTION
The mosh command did not open any 60000..600050 security group ports in my inception VM's security group "default".

Yes, we do need a dedicated inception VM security group.
