### PR TITLE
Allow for trailing whitespace when sanitizing the micro-bosh manifest

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_micro_bosh_deploy.rb
+++ b/lib/bosh-bootstrap/stages/stage_micro_bosh_deploy.rb
@@ -115,9 +115,9 @@ module Bosh::Bootstrap::Stages
         end
       end
 
-      manifest.to_yaml.gsub(/\s![^ ]+$/, '')
+      manifest.to_yaml.gsub(/\s+!\S+/, '')
 
-      # /![^ ]+\s/ removes object notation from the YAML which appears to cause problems when being interpretted by the
+      # /\s+!\S+/ removes object notation from the YAML which appears to cause problems when being interpretted by the
       # Ruby running on the inception vm. A before and after example would look like;
       #
       #   properties: !map:Settingslogic


### PR DESCRIPTION
The YAML produced on the local machine can contain trailing whitespace
in lines, e.g. "properties: !map:Settingslogic ".  Earlier versions of
the sanitization regexp matched such cases, but it got changed to require
an end-of-line in 5b73522cd78e125c.

This version restores the old matching behavior, while still eliminating
preceding whitespace.
