### PR TITLE
Upgrades manifest.yml to support new inception ssh keys

### DIFF
--- a/lib/bosh-bootstrap/cli.rb
+++ b/lib/bosh-bootstrap/cli.rb
@@ -1129,43 +1129,6 @@ module Bosh::Bootstrap
         end
       end
 
-      def migrate_old_settings
-        if migrate_old_ssh_keys?
-          say "Upgrading settings manifest file:"
-          backup_current_settings_file
-        end
-        migrate_old_ssh_keys
-      end
-
-      # Do we need to migrate old ssh keys to new settings format?
-      def migrate_old_ssh_keys?
-        settings["local"] && settings["local"]["private_key_path"]
-      end
-
-      # Migrate this old data
-      #   local:
-      #     public_key_path: /Users/drnic/.ssh/id_rsa.pub
-      #     private_key_path: /Users/drnic/.ssh/id_rsa
-      # into new format:
-      #   inception:
-      #     local_private_key_path: ~/.bosh_bootstrap/ssh/inception (copy of settings.local.private_key_path)
-      #     key_pair:
-      #       name: <name of provider key_pair used when provisioning inception VM>
-      #       private_key: <contents of settings.local.private_key_path file>
-      #       public_key: <contents of settings.local.public_key_path file>
-      def migrate_old_ssh_keys
-        if migrate_old_ssh_keys?
-          say "-> migrating to cache private key for inception VM..."
-          inception_vm_private_key_path # to setup the path in settings
-          settings["inception"]["key_pair"] ||= {}
-          settings["inception"]["key_pair"]["name"] = "fog_default"
-          settings["inception"]["key_pair"]["private_key"] = File.read(settings["local"]["private_key_path"]).strip
-          settings["inception"]["key_pair"]["public_key"] = File.read(settings["local"]["public_key_path"]).strip
-          settings.delete("local")
-          save_settings!
-        end
-      end
-
       def aws?
         settings.fog_credentials.provider == "AWS"
       end


### PR DESCRIPTION
It will store your existing private key in the manifest.yml and recreate `~/.bosh_bootstrap/ssh/inception` private key which is used for all SSH-related activities upon the inception VM

/cc @mrdavidlaing @rkoster can you please code review/test on any existing inception VMs/manifest.yml you have and check that it works and that your manifest.yml has been upgraded?

It automatically backs up your existing manifest.yml
