### PR TITLE
Package mkpasswd doesn't exist in ubuntu 12.04

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -13,6 +13,6 @@ apt-get install build-essential libsqlite3-dev curl rsync git-core \
   tmux mosh \
   libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev \
   runit \
-  genisoimage mkpasswd \
+  genisoimage whois \
   debootstrap kpartx qemu-kvm \
   vim -y


### PR DESCRIPTION
Package mkpasswd doesn't exist in ubuntu 12.04

The same for 12.10 : http://stacksherpa.com/2012/11/how-to-create-a-micro-bosh-stemcell-with-ubuntu-12-10/
