### PR TITLE
Base pkg installation on inception VM: Make it compatible with Ubuntu 12.04

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -8,13 +8,17 @@ fi
 set -e # exit immediately if a simple command exits with a non-zero status
 
 apt-get install python-software-properties
-add-apt-repository ppa:keithw/mosh
+add-apt-repository -y ppa:keithw/mosh
 
 apt-get update
 apt-get install build-essential libsqlite3-dev curl rsync git-core \
   tmux mosh \
   libmysqlclient-dev libxml2-dev libxslt-dev libpq-dev libsqlite3-dev \
   runit \
-  genisoimage mkpasswd \
+  genisoimage \
   debootstrap kpartx qemu-kvm \
   vim -y
+
+if [ "$(lsb_release --release --short)" == '10.04' ]; then
+	apt-get install mkpasswd -y
+fi


### PR DESCRIPTION
This includes not installing mkpasswd (but keeping it installed for 10.04), and adding "-y" to the PPA addition, which was failing due to

```
You are about to add the following PPA to your system:
Mosh is a remote terminal application that supports intermittent connectivity, allows roaming, and provides speculative local echo and line editing of user keystrokes.
More info: https://launchpad.net/~keithw/+archive/mosh
Press [ENTER] to continue or ctrl-c to cancel adding it
```
