### PR TITLE
Base pkg installation on inception VM: Make it compatible with Ubuntu 12.04

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -21,4 +21,6 @@ apt-get install build-essential libsqlite3-dev curl rsync git-core \
 
 if [ "$(lsb_release --release --short)" == '10.04' ]; then
 	apt-get install mkpasswd -y
+else
+	apt-get install whois -y
 fi


### PR DESCRIPTION
This includes installing whois instead of mkpasswd (but keeping it for 10.04). The condition is a little dumb, I assume that if you're not installing on 10.04, then you must be installing on >= 12.04.

Also adding "-y" to the PPA addition, which was failing due to

```
You are about to add the following PPA to your system:
Mosh is a remote terminal application that supports intermittent connectivity, allows roaming, and provides speculative local echo and line editing of user keystrokes.
More info: https://launchpad.net/~keithw/+archive/mosh
Press [ENTER] to continue or ctrl-c to cancel adding it
```
