### PR TITLE
Fixing my previous alteration of the base pkg install script

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm/install_base_packages
@@ -8,7 +8,11 @@ fi
 set -e # exit immediately if a simple command exits with a non-zero status
 
 apt-get install python-software-properties
-add-apt-repository -y ppa:keithw/mosh
+if [ "$(lsb_release --release --short)" == '10.04' ]; then
+  add-apt-repository ppa:keithw/mosh
+else
+  add-apt-repository -y ppa:keithw/mosh
+fi
 
 apt-get update
 apt-get install build-essential libsqlite3-dev curl rsync git-core \


### PR DESCRIPTION
Base packages install: Lesson of the day: even if looks obvious, test. 
Fixing the "-y" option being not present in 10.04 and throwing an error.

Sorry about that. Tested on 10.04 and now works back.
