### PR TITLE
Install bosh-cf via inception Gemfile

### DIFF
--- a/lib/bosh-bootstrap/stages/stage_prepare_inception_vm.rb
+++ b/lib/bosh-bootstrap/stages/stage_prepare_inception_vm.rb
@@ -62,6 +62,7 @@ module Bosh::Bootstrap::Stages
       
       gem "bosh_cli", "~> 1.5.0.pre"
       gem "bosh_cli_plugin_micro", "~> 1.5.0.pre"
+      gem "bosh-cloudfoundry"
       RUBY
     end
   end


### PR DESCRIPTION
v0.10 didn't install bosh-cloudfoundry gem; installing it
via the /var/vcap/store/inception/Gemfile makes it 
available to the ~vcap user when they ssh in.
