### PR TITLE
Don't require Bundler at runtime.

### DIFF
--- a/bin/bosh-bootstrap
+++ b/bin/bosh-bootstrap
@@ -2,10 +2,6 @@
 $:.push File.dirname(__FILE__) + '/../lib'
 
 require "rubygems"
-require "bundler"
-
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-Bundler.setup(:default)
 
 require "bosh-bootstrap"
 require "bosh-bootstrap/thor_cli"


### PR DESCRIPTION
Note that this reverts commits 1c5979d and 060fa5a, requiring you to
"bundle exec" if you're running "bin/bosh-bootstrap" from within
the gem source directory.

Fixes cloudfoundry-community/bosh-bootstrap#218.
Fixes cloudfoundry-community/bosh-bootstrap#219.
