### PR TITLE
Add the `dns_server` security group to the manifest file for MicroBOSH

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/aws.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/aws.rb
@@ -56,6 +56,7 @@ module Bosh::Bootstrap::MicroboshProviders
 
     def security_groups
       ["ssh",
+       "dns_server",
        "bosh_agent_https",
        "bosh_nats_server",
        "bosh_blobstore",

--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -66,6 +66,7 @@ module Bosh::Bootstrap::MicroboshProviders
 
     def security_groups
       ["ssh",
+       "dns_server",
        "bosh_agent_https",
        "bosh_nats_server",
        "bosh_blobstore",


### PR DESCRIPTION
I found that bosh-bootstrap creates the security group `dns_server` on AWS and OpenStack, however it doesn't add the group to the created VM for MicroBOSH.
This commit add the group to the manifest file to fix the problem.
