### PR TITLE
Use udp for the DNS security group

### DIFF
--- a/lib/bosh-bootstrap/network_providers/aws.rb
+++ b/lib/bosh-bootstrap/network_providers/aws.rb
@@ -16,7 +16,7 @@ module Bosh::Bootstrap::NetworkProviders
     def security_groups
       {
         ssh: 22,
-        dns_server: 53,
+        dns_server: { protocol: "udp", ports: (53..53) },
         bosh_nats_server: 4222,
         bosh_agent_https: 6868,
         bosh_blobstore: 25250,

--- a/lib/bosh-bootstrap/network_providers/openstack.rb
+++ b/lib/bosh-bootstrap/network_providers/openstack.rb
@@ -16,7 +16,7 @@ module Bosh::Bootstrap::NetworkProviders
     def security_groups
       {
         ssh: 22,
-        dns_server: 53,
+        dns_server: { protocol: "udp", ports: (53..53) },
         bosh_nats_server: 4222,
         bosh_agent_https: 6868,
         bosh_blobstore: 25250,

--- a/spec/unit/network_providers/aws_spec.rb
+++ b/spec/unit/network_providers/aws_spec.rb
@@ -16,7 +16,7 @@ describe Bosh::Bootstrap::NetworkProviders::AWS do
   it "creates security groups it needs" do
     expected_groups = [
       ["ssh", "ssh", ports: 22],
-      ["dns_server", "dns_server", ports: 53],
+      ["dns_server", "dns_server", ports: { protocol: "udp", ports: (53..53) }],
       ["bosh_nats_server", "bosh_nats_server", ports: 4222],
       ["bosh_agent_https", "bosh_agent_https", ports: 6868],
       ["bosh_blobstore", "bosh_blobstore", ports: 25250],

--- a/spec/unit/network_providers/openstack_spec.rb
+++ b/spec/unit/network_providers/openstack_spec.rb
@@ -15,7 +15,7 @@ describe Bosh::Bootstrap::NetworkProviders::OpenStack do
   it "creates security groups it needs" do
     expected_groups = [
       ["ssh", "ssh", ports: 22],
-      ["dns_server", "dns_server", ports: 53],
+      ["dns_server", "dns_server", ports: { protocol: "udp", ports: (53..53) }],
       ["bosh_nats_server", "bosh_nats_server", ports: 4222],
       ["bosh_agent_https", "bosh_agent_https", ports: 6868],
       ["bosh_blobstore", "bosh_blobstore", ports: 25250],


### PR DESCRIPTION
Hi Dr Nic,

This commit fixes BOSH VMs cannot resolve host names with the built in DNS server.
