### PR TITLE
[openstack] properties for micro_bosh.yml [fixes #248]

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -21,7 +21,12 @@ module Bosh::Bootstrap::MicroboshProviders
        "apply_spec"=>
         {"agent"=>
           {"blobstore"=>{"address"=>public_ip},
-           "nats"=>{"address"=>public_ip}}}
+           "nats"=>{"address"=>public_ip}},
+         "properties"=>
+           {"director"=>
+             {"max_threads"=>3},
+            "hm"=>{"resurrector_enabled" => true},
+            "ntp"=>["0.north-america.pool.ntp.org","1.north-america.pool.ntp.org"]}}
       })
     end
 

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.yml
@@ -34,3 +34,11 @@ apply_spec:
       address: 1.2.3.4
     nats:
       address: 1.2.3.4
+  properties:
+    director:
+      max_threads: 3
+    hm:
+      resurrector_enabled: true
+    ntp:
+      - 0.north-america.pool.ntp.org
+      - 1.north-america.pool.ntp.org


### PR DESCRIPTION
Constrains the API calls to keep within default POST 10/min limits
