### PR TITLE
Allow updates to an existing microBOSH installation

### DIFF
--- a/lib/bosh-bootstrap/microbosh.rb
+++ b/lib/bosh-bootstrap/microbosh.rb
@@ -67,7 +67,7 @@ gem "bosh_cli_plugin_micro"
   def deploy_or_update(bosh_name, stemcell)
     chdir("deployments") do
       bundle "exec bosh micro deployment", bosh_name
-      bundle "exec bosh -n micro deploy", stemcell
+      bundle "exec bosh -n micro deploy --update-if-exists", stemcell
     end
   end
 end

--- a/spec/unit/microbosh_spec.rb
+++ b/spec/unit/microbosh_spec.rb
@@ -14,7 +14,7 @@ describe Bosh::Bootstrap::Microbosh do
     setting "bosh.stemcell", path_or_ami
     subject.should_receive(:sh).with("bundle install")
     subject.should_receive(:sh).with("bundle exec bosh micro deployment test-bosh")
-    subject.should_receive(:sh).with("bundle exec bosh -n micro deploy #{path_or_ami}")
+    subject.should_receive(:sh).with("bundle exec bosh -n micro deploy --update-if-exists #{path_or_ami}")
     subject.deploy(settings)
   end
 


### PR DESCRIPTION
Here is the new syntax for bosh micro deploy:

micro deploy [] [--update] [--update-if-exists]
Deploy a micro BOSH instance to the currently selected deployment
--update update existing instance
--update-if-exists create new or update existing instance

When I ran bosh-bootstrap deploy on an existing instance it fails asking if I meant to update. The newer syntax allows for --update-if-exists in addition to --update and it works very well. 

Passed test at: https://travis-ci.org/lookitup4me/bosh-bootstrap/builds/13140446
