### PR TITLE
Update openstack.rb

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -78,7 +78,7 @@ module Bosh::Bootstrap::MicroboshProviders
     end
 
     def stemcell_uri
-      "http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz"
+      "http://bosh-jenkins-artifacts.s3.amazonaws.com/micro-bosh-stemcell/openstack/latest-micro-bosh-stemcell-openstack.tgz"
     end
   end
 end


### PR DESCRIPTION
bosh stemcell url was there previously instead of microbosh stemcells
