### PR TITLE
No longer creating separate Gemfile and running bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Ensure bosh-bootstrap & bosh micro support same gems for traveling-bosh
-gem "bosh_cli_plugin_micro"
-
 if File.directory?("../cyoi")
   gem "cyoi", path: "../cyoi"
 end

--- a/bosh-bootstrap.gemspec
+++ b/bosh-bootstrap.gemspec
@@ -22,6 +22,7 @@ EOS
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "bosh_cli_plugin_micro"
   gem.add_dependency "cyoi", "~> 0.11"
   gem.add_dependency "fog", "~> 1.11"
   gem.add_dependency "readwritesettings", "~> 3.0"

--- a/lib/bosh-bootstrap/cli/commands/delete.rb
+++ b/lib/bosh-bootstrap/cli/commands/delete.rb
@@ -10,8 +10,8 @@ class Bosh::Bootstrap::Cli::Commands::Delete
 
   def perform
     chdir(deployment_dir) do
-      bundle "exec bosh -n micro deployment #{bosh_name}"
-      bundle "exec bosh -n micro delete"
+      run "bosh", "-n", "micro", "deployment", bosh_name
+      run "bosh", "-n", "micro", "delete"
     end
   end
 

--- a/lib/bosh-bootstrap/cli/helpers/bundle.rb
+++ b/lib/bosh-bootstrap/cli/helpers/bundle.rb
@@ -11,4 +11,11 @@ module Bosh::Bootstrap::Cli::Helpers::Bundle
       sh "bundle #{args.join(' ')}"
     }
   end
+
+  def run(*args)
+    Bundler.with_clean_env {
+      ENV.delete 'RUBYOPT'
+      sh *args
+    }
+  end
 end

--- a/lib/bosh-bootstrap/microbosh.rb
+++ b/lib/bosh-bootstrap/microbosh.rb
@@ -38,35 +38,20 @@ class Bosh::Bootstrap::Microbosh
     @manifest_yml = File.join(deployments_dir, bosh_name, "micro_bosh.yml")
     mkdir_p(File.dirname(manifest_yml))
     chdir(base_path) do
-      setup_gems
       create_microbosh_yml(settings)
       deploy_or_update(settings.bosh.name, settings.bosh.stemcell_path)
     end
   end
 
   protected
-  def setup_gems
-    gempath = File.expand_path("../../..", __FILE__)
-    pwd = File.expand_path(".")
-    File.open("Gemfile", "w") do |f|
-      f << <<-RUBY
-source 'https://rubygems.org'
-
-gem "bosh_cli_plugin_micro"
-      RUBY
-    end
-    rm_rf "Gemfile.lock"
-    bundle "install"
-  end
-
   def create_microbosh_yml(settings)
     provider.create_microbosh_yml(settings)
   end
 
   def deploy_or_update(bosh_name, stemcell)
     chdir("deployments") do
-      bundle "exec bosh micro deployment", bosh_name
-      bundle "exec bosh -n micro deploy --update-if-exists", stemcell
+      run "bosh", "micro", "deployment", bosh_name
+      run "bosh", "-n", "micro", "deploy", "--update-if-exists", stemcell
     end
   end
 end

--- a/spec/unit/commands/delete_spec.rb
+++ b/spec/unit/commands/delete_spec.rb
@@ -11,8 +11,8 @@ describe Bosh::Bootstrap::Cli::Commands::Delete do
   it "deletes microbosh VM" do
     setting "bosh.name", "test-bosh"
     mkdir_p(File.join(settings_dir, "deployments"))
-    expect(subject).to receive(:sh).with("bundle exec bosh -n micro deployment test-bosh")
-    expect(subject).to receive(:sh).with("bundle exec bosh -n micro delete")
+    expect(subject).to receive(:sh).with("bosh", "-n", "micro", "deployment", "test-bosh")
+    expect(subject).to receive(:sh).with("bosh", "-n", "micro", "delete")
     subject.perform
   end
 end

--- a/spec/unit/microbosh_spec.rb
+++ b/spec/unit/microbosh_spec.rb
@@ -12,9 +12,8 @@ describe Bosh::Bootstrap::Microbosh do
   it "deploys new microbosh" do
     setting "bosh.name", "test-bosh"
     setting "bosh.stemcell_path", stemcell_path
-    expect(subject).to receive(:sh).with("bundle install")
-    expect(subject).to receive(:sh).with("bundle exec bosh micro deployment test-bosh")
-    expect(subject).to receive(:sh).with("bundle exec bosh -n micro deploy --update-if-exists #{stemcell_path}")
+    expect(subject).to receive(:sh).with("bosh", "micro", "deployment", "test-bosh")
+    expect(subject).to receive(:sh).with("bosh", "-n", "micro", "deploy", "--update-if-exists", stemcell_path)
     subject.deploy(settings)
   end
 


### PR DESCRIPTION
bosh CLI seems to be update enough in its dependencies (`fog` especially) to merge the `bosh_cli_plugin_micro` into the gemspec without clashing.

Required for inclusion in traveling-bosh - cannot call back to `bundle` or `bosh` and expect the same `bosh` experience.
