### PR TITLE
add the resurrector to the AWS provider by default

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/aws.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/aws.rb
@@ -17,7 +17,10 @@ module Bosh::Bootstrap::MicroboshProviders
         {"agent"=>
           {"blobstore"=>{"address"=>public_ip},
            "nats"=>{"address"=>public_ip}},
-         "properties"=>{"aws_registry"=>{"address"=>public_ip}}}})
+          "properties"=>
+            {"aws_registry"=>{"address"=>public_ip},
+            "hm"=>{"resurrector_enabled" => true}}},
+      })
       if az = settings.exists?("provider.az")
         data["resources"]["cloud_properties"]["availability_zone"] = az
       end

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
@@ -31,5 +31,7 @@ apply_spec:
     nats:
       address: 1.2.3.4
   properties:
+    hm:
+      resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
@@ -30,5 +30,7 @@ apply_spec:
     nats:
       address: 1.2.3.4
   properties:
+    hm:
+      resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
@@ -34,6 +34,8 @@ apply_spec:
     nats:
       address: 1.2.3.4
   properties:
+    hm:
+      resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4
     dns:

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
@@ -34,6 +34,8 @@ apply_spec:
     nats:
       address: 1.2.3.4
   properties:
+    hm:
+      resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4
     dns:


### PR DESCRIPTION
I only added it to the AWS provider, as that's the only one that I could personally test.