### PR TITLE
double the microbosh persistent disk to 32GB from 16

### DIFF
--- a/lib/bosh-bootstrap/cli/commands/deploy.rb
+++ b/lib/bosh-bootstrap/cli/commands/deploy.rb
@@ -72,7 +72,7 @@ class Bosh::Bootstrap::Cli::Commands::Deploy
   end
 
   def perform_microbosh_deploy
-    settings.set("bosh.persistent_disk", 16 * 1024)
+    settings.set("bosh.persistent_disk", 32 * 1024)
     @microbosh ||= Bosh::Bootstrap::Microbosh.new(settings_dir, microbosh_provider)
     @microbosh.deploy(settings)
   end

--- a/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
@@ -44,7 +44,7 @@ module Bosh::Bootstrap::MicroboshProviders
     end
 
     # resources:
-    #  persistent_disk: 16384
+    #  persistent_disk: 32768
     #  cloud_properties:
     #    ram: 4096
     #    disk: 10240

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
@@ -6,7 +6,7 @@ network:
   type: dynamic
   vip: 1.2.3.4
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
     availability_zone: us-west-2a

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
@@ -6,7 +6,7 @@ network:
   type: dynamic
   vip: 1.2.3.4
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
@@ -10,7 +10,7 @@ network:
   cloud_properties:
     subnet: subnet-123456
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
@@ -10,7 +10,7 @@ network:
   cloud_properties:
     subnet: subnet-123456
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
@@ -8,7 +8,7 @@ network:
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
@@ -8,7 +8,7 @@ network:
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
@@ -8,7 +8,7 @@ network:
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
@@ -6,7 +6,7 @@ network:
   type: dynamic
   vip: 1.2.3.4
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
@@ -8,7 +8,7 @@ network:
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
-  persistent_disk: 16384
+  persistent_disk: 32768
   cloud_properties:
     instance_type: m1.medium
 cloud:

--- a/spec/assets/microbosh_yml/micro_bosh.vsphere.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.vsphere.yml
@@ -12,10 +12,10 @@ network:
   cloud_properties: 
     name: VLAN2194
 resources:
-  persistent_disk: "16384"
+  persistent_disk: "32768"
   cloud_properties:
     ram: "2048"
-    disk: "16384"
+    disk: "32768"
     cpu: "2"
 cloud: 
   plugin: vsphere

--- a/spec/unit/microbosh_providers/aws_spec.rb
+++ b/spec/unit/microbosh_providers/aws_spec.rb
@@ -19,7 +19,7 @@ describe Bosh::Bootstrap::MicroboshProviders::AWS do
     setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
     setting "bosh.name", "test-bosh"
     setting "bosh.salted_password", "salted_password"
-    setting "bosh.persistent_disk", 16384
+    setting "bosh.persistent_disk", 32768
 
     subject = Bosh::Bootstrap::MicroboshProviders::AWS.new(microbosh_yml, settings, fog_compute)
 
@@ -38,7 +38,7 @@ describe Bosh::Bootstrap::MicroboshProviders::AWS do
     setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
     setting "bosh.name", "test-bosh"
     setting "bosh.salted_password", "salted_password"
-    setting "bosh.persistent_disk", 16384
+    setting "bosh.persistent_disk", 32768
 
     subject = Bosh::Bootstrap::MicroboshProviders::AWS.new(microbosh_yml, settings, fog_compute)
 
@@ -58,7 +58,7 @@ describe Bosh::Bootstrap::MicroboshProviders::AWS do
     setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
     setting "bosh.name", "test-bosh"
     setting "bosh.salted_password", "salted_password"
-    setting "bosh.persistent_disk", 16384
+    setting "bosh.persistent_disk", 32768
 
     subject = Bosh::Bootstrap::MicroboshProviders::AWS.new(microbosh_yml, settings, fog_compute)
 
@@ -198,7 +198,7 @@ describe Bosh::Bootstrap::MicroboshProviders::AWS do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
       setting "recursor", "4.5.6.7"
 
       subject = Bosh::Bootstrap::MicroboshProviders::AWS.new(microbosh_yml, settings, fog_compute)

--- a/spec/unit/microbosh_providers/openstack_spec.rb
+++ b/spec/unit/microbosh_providers/openstack_spec.rb
@@ -19,7 +19,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
 
       subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
 
@@ -43,7 +43,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
 
       subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
 
@@ -64,7 +64,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
 
       subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
 
@@ -85,7 +85,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
 
       setting "provider.options.boot_from_volume", true
 
@@ -109,7 +109,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 16384
+      setting "bosh.persistent_disk", 32768
       setting "recursor", "4.5.6.7"
 
       subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)

--- a/spec/unit/microbosh_providers/vsphere_spec.rb
+++ b/spec/unit/microbosh_providers/vsphere_spec.rb
@@ -13,9 +13,9 @@ describe Bosh::Bootstrap::MicroboshProviders::VSphere do
     setting "provider.credentials.vsphere_username", "user"
     setting "provider.credentials.vsphere_password", "TempP@ss"
 
-    setting "provider.resources.persistent_disk", "16384"
+    setting "provider.resources.persistent_disk", "32768"
     setting "provider.resources.ram", "2048"
-    setting "provider.resources.disk", "16384"
+    setting "provider.resources.disk", "32768"
     setting "provider.resources.cpu", "2"
 
     # TODO - perhaps network.ip_address is better?


### PR DESCRIPTION
This should help with the amount of releases that can be stored in the blobstore at once, among other things.