### PR TITLE
Fix deprecation warnings in tests by updating syntax

### DIFF
--- a/spec/unit/cli/bootstrap_spec.rb
+++ b/spec/unit/cli/bootstrap_spec.rb
@@ -27,21 +27,21 @@ begin
     it "runs deploy command" do
       cmd = double(Bosh::Bootstrap::Cli::Commands::Deploy)
       expect(cmd).to receive(:perform)
-      Bosh::Bootstrap::Cli::Commands::Deploy.stub(:new).and_return(cmd)
+      allow(Bosh::Bootstrap::Cli::Commands::Deploy).to receive(:new).and_return(cmd)
       cli.deploy
     end
 
     it "runs delete command" do
       cmd = double(Bosh::Bootstrap::Cli::Commands::Delete)
       expect(cmd).to receive(:perform)
-      Bosh::Bootstrap::Cli::Commands::Delete.stub(:new).and_return(cmd)
+      allow(Bosh::Bootstrap::Cli::Commands::Delete).to receive(:new).and_return(cmd)
       cli.delete
     end
 
     it "runs ssh command" do
       cmd = double(Bosh::Bootstrap::Cli::Commands::SSH)
       expect(cmd).to receive(:perform)
-      Bosh::Bootstrap::Cli::Commands::SSH.stub(:new).and_return(cmd)
+      allow(Bosh::Bootstrap::Cli::Commands::SSH).to receive(:new).and_return(cmd)
       cli.ssh
     end
   end

--- a/spec/unit/microbosh_providers/base_spec.rb
+++ b/spec/unit/microbosh_providers/base_spec.rb
@@ -18,7 +18,7 @@ describe Bosh::Bootstrap::MicroboshProviders::Base do
         setting "recursor", "4.5.6.7"
 
         subject.create_microbosh_yml(settings)
-        File.should be_exists(microbosh_yml)
+        expect(File).to be_exists(microbosh_yml)
         yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.with_recursor.yml"))
       end
     end
@@ -26,7 +26,7 @@ describe Bosh::Bootstrap::MicroboshProviders::Base do
     context "when recursor is not provided" do
       it "does not adds the recursor to the yml" do
         subject.create_microbosh_yml(settings)
-        File.should be_exists(microbosh_yml)
+        expect(File).to be_exists(microbosh_yml)
         yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.without_recursor.yml"))
       end
     end

--- a/spec/unit/microbosh_providers/openstack_spec.rb
+++ b/spec/unit/microbosh_providers/openstack_spec.rb
@@ -115,7 +115,7 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
 
       subject.create_microbosh_yml(settings)
-      File.should be_exists(microbosh_yml)
+      expect(File).to be_exists(microbosh_yml)
       yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_recursor.yml"))
     end
   end


### PR DESCRIPTION
Specifically, replacing 'should' with 'expect', and calls to 'stub' with 'allow', as per https://github.com/rspec/rspec-mocks#method-stubs and http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax