### PR TITLE
Added support for state_timeout for openstack

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -87,6 +87,10 @@ module Bosh::Bootstrap::MicroboshProviders
       {"instance_type"=>"m1.medium"}
     end
 
+    def provider_state_timeout
+      settings.exists?("provider") && settings.provider.exists?("state_timeout") ? settings.provider.state_timeout : 300
+    end
+
     def cloud_properties
       {
         "auth_url"=>settings.provider.credentials.openstack_auth_url,
@@ -96,6 +100,7 @@ module Bosh::Bootstrap::MicroboshProviders
         "region"=>region,
         "default_security_groups"=>security_groups,
         "default_key_name"=>microbosh_name,
+        "state_timeout"=>provider_state_timeout,
         "private_key"=>private_key_path,
         # TODO: Only ignore SSL verification if requested by user
         "connection_options"=>{

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
@@ -25,6 +25,7 @@ cloud:
       - dns-server
       - bosh
       default_key_name: test-bosh
+      state_timeout: 300
       private_key: ~/.microbosh/ssh/test-bosh
       connection_options:
         ssl_verify_peer: false

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
@@ -25,6 +25,7 @@ cloud:
       - dns-server
       - bosh
       default_key_name: test-bosh
+      state_timeout: 300
       private_key: ~/.microbosh/ssh/test-bosh
       connection_options:
         ssl_verify_peer: false

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
@@ -25,6 +25,7 @@ cloud:
       - dns-server
       - bosh
       default_key_name: test-bosh
+      state_timeout: 300
       private_key: ~/.microbosh/ssh/test-bosh
       connection_options:
         ssl_verify_peer: false

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
@@ -25,6 +25,7 @@ cloud:
       - dns-server
       - bosh
       default_key_name: test-bosh
+      state_timeout: 300
       private_key: ~/.microbosh/ssh/test-bosh
       connection_options:
         ssl_verify_peer: false

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
@@ -5,6 +5,8 @@ logging:
 network:
   type: dynamic
   vip: 1.2.3.4
+  cloud_properties:
+    net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
   persistent_disk: 32768
   cloud_properties:
@@ -23,7 +25,7 @@ cloud:
       - dns-server
       - bosh
       default_key_name: test-bosh
-      state_timeout: 300
+      state_timeout: 600
       private_key: ~/.microbosh/ssh/test-bosh
       connection_options:
         ssl_verify_peer: false

--- a/spec/unit/microbosh_providers/openstack_spec.rb
+++ b/spec/unit/microbosh_providers/openstack_spec.rb
@@ -118,6 +118,28 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       expect(File).to be_exists(microbosh_yml)
       yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_recursor.yml"))
     end
+
+    it "adds state_timeout if provided" do
+      setting "provider.name", "openstack"
+      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
+      setting "provider.credentials.openstack_username", "USER"
+      setting "provider.credentials.openstack_api_key", "PASSWORD"
+      setting "provider.credentials.openstack_tenant", "TENANT"
+      setting "provider.credentials.openstack_region", "REGION"
+      setting "provider.state_timeout", 600
+      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
+      setting "address.pool_name", "INTERNET"
+      setting "address.ip", "1.2.3.4" # network.vip
+      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
+      setting "bosh.name", "test-bosh"
+      setting "bosh.salted_password", "salted_password"
+      setting "bosh.persistent_disk", 32768
+
+      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
+      subject.create_microbosh_yml(settings)
+      expect(File).to be_exists(microbosh_yml)
+      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_state_timeout.yml"))
+    end
   end
 
   describe "existing stemcells as openstack images" do
@@ -143,5 +165,4 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
       expect(subject.find_image_for_stemcell("xxxx", "12345")).to be_nil
     end
   end
-
 end


### PR DESCRIPTION
bosh doesn't like it when openstack takes >5 minutes.
This allows a provider.state_timeout override in settings.yml
to propagate through and fine-tune the timeout.