### PR TITLE
Allow specify custom ntp servers on OpenStack

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/base.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/base.rb
@@ -66,6 +66,11 @@ class Bosh::Bootstrap::MicroboshProviders::Base
   end
 
   def ntp_servers
+    if settings.exists?("provider.ntps")
+      servers = settings.provider.ntps
+      return servers.is_a?(String) ? servers.split(",") : servers
+    end
+
     settings.exists?("ntp") ? settings.ntp : DEFAULT_NTP_SERVERS
   end
 

--- a/lib/bosh-bootstrap/microbosh_providers/base.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/base.rb
@@ -8,6 +8,8 @@ require "rake/file_utils"
 class Bosh::Bootstrap::MicroboshProviders::Base
   include FileUtils
 
+  DEFAULT_NTP_SERVERS = %w[0.pool.ntp.org 1.pool.ntp.org]
+
   attr_reader :manifest_path
   attr_reader :settings
   attr_reader :fog_compute
@@ -61,6 +63,10 @@ class Bosh::Bootstrap::MicroboshProviders::Base
 
   def proxy?
     settings.exists?("proxy")
+  end
+
+  def ntp_servers
+    settings.exists?("ntp") ? settings.ntp : DEFAULT_NTP_SERVERS
   end
 
   def jenkins_bucket

--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -21,7 +21,7 @@ module Bosh::Bootstrap::MicroboshProviders
            {"director"=>
              {"max_threads"=>3},
             "hm"=>{"resurrector_enabled" => true},
-            "ntp"=>["0.north-america.pool.ntp.org","1.north-america.pool.ntp.org"]}}
+            "ntp"=> ntp_servers }}
       })
       if proxy?
         data["apply_spec"]["properties"]["director"]["env"] = proxy

--- a/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
@@ -15,7 +15,7 @@ module Bosh::Bootstrap::MicroboshProviders
         "cloud"=>
          {"plugin"=>"vsphere",
           "properties"=>{
-            "agent"=>{"ntp"=>ntps},
+            "agent"=>{"ntp"=>ntp_servers},
             "vcenters"=>[vcenter_configuration]
           }}})
     end
@@ -58,12 +58,6 @@ module Bosh::Bootstrap::MicroboshProviders
           "cpu"=>settings.provider.resources.cpu
         }
       }
-    end
-
-    def ntps
-      ntp_servers = settings.provider.ntps
-      ntp_servers = ntp_servers.split(",") if ntp_servers.is_a?(String)
-      ntp_servers
     end
 
     # vcenters:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
@@ -42,5 +42,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
@@ -42,5 +42,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
@@ -40,5 +40,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_ntp.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_ntp.yml
@@ -42,5 +42,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.pool.ntp.org
-      - 1.pool.ntp.org
+      - 1.1.2.2
+      - 1.1.2.3

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_proxy.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_proxy.yml
@@ -3,8 +3,8 @@ name: test-bosh
 logging:
   level: DEBUG
 network:
-  type: dynamic
-  vip: 1.2.3.4
+  type: manual
+  ip: 10.10.10.3
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
@@ -33,9 +33,9 @@ cloud:
 apply_spec:
   agent:
     blobstore:
-      address: 1.2.3.4
+      address: 10.10.10.3
     nats:
-      address: 1.2.3.4
+      address: 10.10.10.3
   properties:
     director:
       max_threads: 3
@@ -45,5 +45,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
@@ -3,8 +3,8 @@ name: test-bosh
 logging:
   level: DEBUG
 network:
-  type: dynamic
-  vip: 1.2.3.4
+  type: manual
+  ip: 10.10.10.3
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
@@ -33,9 +33,9 @@ cloud:
 apply_spec:
   agent:
     blobstore:
-      address: 1.2.3.4
+      address: 10.10.10.3
     nats:
-      address: 1.2.3.4
+      address: 10.10.10.3
   properties:
     dns:
       recursor: 4.5.6.7
@@ -44,5 +44,5 @@ apply_spec:
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
@@ -3,8 +3,8 @@ name: test-bosh
 logging:
   level: DEBUG
 network:
-  type: dynamic
-  vip: 1.2.3.4
+  type: manual
+  ip: 10.10.10.3
   cloud_properties:
     net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
 resources:
@@ -33,14 +33,14 @@ cloud:
 apply_spec:
   agent:
     blobstore:
-      address: 1.2.3.4
+      address: 10.10.10.3
     nats:
-      address: 1.2.3.4
+      address: 10.10.10.3
   properties:
     director:
       max_threads: 3
     hm:
       resurrector_enabled: true
     ntp:
-      - 0.north-america.pool.ntp.org
-      - 1.north-america.pool.ntp.org
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/unit/microbosh_providers/openstack_spec.rb
+++ b/spec/unit/microbosh_providers/openstack_spec.rb
@@ -4,172 +4,122 @@ require "bosh-bootstrap/microbosh_providers/openstack"
 describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
   include Bosh::Bootstrap::Cli::Helpers::Settings
 
-  let(:microbosh_yml) { File.expand_path("~/.microbosh/deployments/micro_bosh.yml")}
   let(:fog_compute) { instance_double("Fog::Compute::OpenStack") }
+  let(:microbosh_yml) { File.expand_path("~/.microbosh/deployments/micro_bosh.yml")}
 
-  context "creates micro_bosh.yml manifest" do
-    it "on nova with floating IP" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "address.ip", "1.2.3.4"
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
-
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
-
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.nova_vip.yml"))
+  describe "microbosh yml" do
+    subject do
+      Bosh::Bootstrap::MicroboshProviders::OpenStack
+        .new(microbosh_yml, settings, fog_compute)
     end
 
-
-
-    it "on neutron with public gateway & floating IP" do
+    before do
       setting "provider.name", "openstack"
       setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
       setting "provider.credentials.openstack_username", "USER"
       setting "provider.credentials.openstack_api_key", "PASSWORD"
       setting "provider.credentials.openstack_tenant", "TENANT"
       setting "provider.credentials.openstack_region", "REGION"
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.pool_name", "INTERNET"
-      setting "address.ip", "1.2.3.4" # network.vip
       setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
       setting "bosh.name", "test-bosh"
       setting "bosh.salted_password", "salted_password"
       setting "bosh.persistent_disk", 32768
-
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
-
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.neutron_vip.yml"))
     end
 
-    it "on neutron with internal static IP only" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.ip", "10.10.10.3" # network.ip
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
+    context "on nova with floating IP" do
+      before do
+        setting "address.ip", "1.2.3.4"
+      end
 
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
+      it "creates micro_bosh.yml manifest" do
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.nova_vip.yml"))
+      end
 
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.neutron_manual.yml"))
     end
 
-    it "boot from volume" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.ip", "10.10.10.3" # network.ip
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
+    context "on neutron with public gateway & floating IP" do
+      before do
+        setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
+        setting "address.pool_name", "INTERNET"
+        setting "address.ip", "1.2.3.4" # network.vip
+      end
 
-      setting "provider.options.boot_from_volume", true
+      it "creates micro_bosh.yml manifest" do
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.neutron_vip.yml"))
+      end
 
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
-
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.boot_from_volume.yml"))
     end
+    context "on neutron with internal static IP only" do
+      before do
+        setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
+        setting "address.ip", "10.10.10.3" # network.ip
+      end
 
-    it "adds recursor if present" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.pool_name", "INTERNET"
-      setting "address.ip", "1.2.3.4" # network.vip
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
-      setting "recursor", "4.5.6.7"
+      it "creates micro_bosh.yml manifest" do
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.neutron_manual.yml"))
+      end
 
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
-
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_recursor.yml"))
     end
+    context "settings" do
+      before do
+        setting "address.ip", "10.10.10.3" # network.ip
+        setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
+      end
 
-    it "adds proxy if present" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.pool_name", "INTERNET"
-      setting "address.ip", "1.2.3.4" # network.vip
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
-      setting "proxy.http_proxy", "http://192.168.1.100:8080"
-      setting "proxy.https_proxy", "https://192.168.1.100:8080"
+      it "boot from volume" do
+        setting "provider.options.boot_from_volume", true
 
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.boot_from_volume.yml"))
+      end
 
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_proxy.yml"))
-    end
+      it "adds recursor if present" do
+        setting "recursor", "4.5.6.7"
 
-    it "adds state_timeout if provided" do
-      setting "provider.name", "openstack"
-      setting "provider.credentials.openstack_auth_url", "http://10.0.0.2:5000/v2.0/tokens"
-      setting "provider.credentials.openstack_username", "USER"
-      setting "provider.credentials.openstack_api_key", "PASSWORD"
-      setting "provider.credentials.openstack_tenant", "TENANT"
-      setting "provider.credentials.openstack_region", "REGION"
-      setting "provider.state_timeout", 600
-      setting "address.subnet_id", "7b8788eb-b49e-4424-9065-75a6b07094ea"
-      setting "address.pool_name", "INTERNET"
-      setting "address.ip", "1.2.3.4" # network.vip
-      setting "key_pair.path", "~/.microbosh/ssh/test-bosh"
-      setting "bosh.name", "test-bosh"
-      setting "bosh.salted_password", "salted_password"
-      setting "bosh.persistent_disk", 32768
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_recursor.yml"))
+      end
 
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
-      subject.create_microbosh_yml(settings)
-      expect(File).to be_exists(microbosh_yml)
-      yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_state_timeout.yml"))
+      it "adds proxy if present" do
+        setting "proxy.http_proxy", "http://192.168.1.100:8080"
+        setting "proxy.https_proxy", "https://192.168.1.100:8080"
+
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_proxy.yml"))
+      end
+
+      it "adds state_timeout if provided" do
+        setting "provider.state_timeout", 600
+
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_state_timeout.yml"))
+      end
+
+      it "uses custom ntp if provided" do
+        setting "ntp", %w[1.1.2.2 1.1.2.3]
+
+
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.with_ntp.yml"))
+      end
     end
   end
 
   describe "existing stemcells as openstack images" do
-
     it "finds match" do
-      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack.new(microbosh_yml, settings, fog_compute)
+      subject = Bosh::Bootstrap::MicroboshProviders::OpenStack
+                .new(microbosh_yml, settings, fog_compute)
       expect(subject).to receive(:owned_images).and_return([
         instance_double("Fog::Compute::OpenStack::Image",
           name: "BOSH-14c85f35-3dd3-4200-af85-ada65216b2de",
@@ -178,7 +128,8 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
               key: "name", value: "bosh-openstack-kvm-ubuntu-trusty-go_agent"),
             instance_double("Fog::Compute::OpenStack::Metadata",
               key: "version", value: "2732"),
-        ])
+          ]
+        )
       ])
       expect(subject.find_image_for_stemcell("bosh-openstack-kvm-ubuntu-trusty-go_agent", "2732")).to eq("BOSH-14c85f35-3dd3-4200-af85-ada65216b2de")
     end


### PR DESCRIPTION
This PR adds support for specifying a custom `ntp` server array in your `settings.yml` file.
It also moved similar logic from the vsphere provider into the base class.