### PR TITLE
Move ntp to default_spec + set ntp for agent and director

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/aws.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/aws.rb
@@ -4,7 +4,7 @@ module Bosh::Bootstrap::MicroboshProviders
   class AWS < Base
 
     def to_hash
-      data = super.merge({
+      data = super.deep_merge({
       "network"=>network_configuration,
        "resources"=>
         {"persistent_disk"=>persistent_disk,

--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -20,8 +20,7 @@ module Bosh::Bootstrap::MicroboshProviders
          "properties"=>
            {"director"=>
              {"max_threads"=>3},
-            "hm"=>{"resurrector_enabled" => true},
-            "ntp"=> ntp_servers }}
+            "hm"=>{"resurrector_enabled" => true}}}
       })
       if proxy?
         data["apply_spec"]["properties"]["director"]["env"] = proxy

--- a/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/vsphere.rb
@@ -9,13 +9,12 @@ module Bosh::Bootstrap::MicroboshProviders
     end
 
     def to_hash
-      super.merge({
+      super.deep_merge({
         "network" => network_configuration,
         "resources" => resource_configuration,
         "cloud"=>
          {"plugin"=>"vsphere",
           "properties"=>{
-            "agent"=>{"ntp"=>ntp_servers},
             "vcenters"=>[vcenter_configuration]
           }}})
     end

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.us-west-2a.yml
@@ -27,6 +27,10 @@ cloud:
       - bosh
       default_key_name: test-bosh
       ec2_private_key: ~/.microbosh/ssh/test-bosh
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:
@@ -38,3 +42,6 @@ apply_spec:
       resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_ec2.yml
@@ -26,6 +26,10 @@ cloud:
       - bosh
       default_key_name: test-bosh
       ec2_private_key: ~/.microbosh/ssh/test-bosh
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:
@@ -37,3 +41,6 @@ apply_spec:
       resurrector_enabled: true
     aws_registry:
       address: 1.2.3.4
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc.yml
@@ -30,6 +30,10 @@ cloud:
       - bosh-vpc-123456
       default_key_name: test-bosh
       ec2_private_key: ~/.microbosh/ssh/test-bosh
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:
@@ -43,3 +47,6 @@ apply_spec:
       address: 1.2.3.4
     dns:
       recursor: 1.2.0.2
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc_proxy.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc_proxy.yml
@@ -30,6 +30,10 @@ cloud:
       - bosh-vpc-123456
       default_key_name: test-bosh
       ec2_private_key: ~/.microbosh/ssh/test-bosh
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:
@@ -47,3 +51,6 @@ apply_spec:
       env:
         http_proxy: http://192.168.1.100:8080
         https_proxy: https://192.168.1.100:8080
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.aws_vpc_recursor.yml
@@ -30,6 +30,10 @@ cloud:
       - bosh-vpc-123456
       default_key_name: test-bosh
       ec2_private_key: ~/.microbosh/ssh/test-bosh
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:
@@ -43,3 +47,6 @@ apply_spec:
       address: 1.2.3.4
     dns:
       recursor: 4.5.6.7
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.base.with_ntp.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.base.with_ntp.yml
@@ -6,11 +6,11 @@ cloud:
   properties:
     agent:
       ntp:
-        - 0.pool.ntp.org
-        - 1.pool.ntp.org
+        - 0.foo.pool.ntp.org
+        - 1.foo.pool.ntp.org
 apply_spec:
   properties:
     ntp:
-      - 0.pool.ntp.org
-      - 1.pool.ntp.org
+      - 0.foo.pool.ntp.org
+      - 1.foo.pool.ntp.org
 

--- a/spec/assets/microbosh_yml/micro_bosh.base.with_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.base.with_recursor.yml
@@ -2,7 +2,16 @@
 name: test-bosh
 logging:
   level: DEBUG
+cloud:
+  properties:
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   properties:
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
     dns:
       recursor: 4.5.6.7

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.boot_from_volume.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: true
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_vip.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.nova_vip.yml
@@ -28,6 +28,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_ntp.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_ntp.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+      - 1.1.2.2
+      - 1.1.2.3
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_proxy.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_proxy.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_recursor.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.with_state_timeout.yml
@@ -30,6 +30,10 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
 apply_spec:
   agent:
     blobstore:

--- a/spec/assets/microbosh_yml/micro_bosh.vsphere.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.vsphere.yml
@@ -38,3 +38,8 @@ cloud:
         allow_mixed_datastores: true
         clusters: 
         - CLUSTER01
+apply_spec:
+  properties:
+    ntp:
+      - ntp01.las01.emcatmos.com
+      - ntp02.las01.emcatmos.com

--- a/spec/unit/microbosh_providers/base_spec.rb
+++ b/spec/unit/microbosh_providers/base_spec.rb
@@ -1,4 +1,3 @@
-
 require "readwritesettings"
 require "bosh-bootstrap/microbosh_providers/base"
 
@@ -8,7 +7,6 @@ describe Bosh::Bootstrap::MicroboshProviders::Base do
   let(:microbosh_yml) { File.expand_path("~/.microbosh/deployments/micro_bosh.yml")}
   let(:fog_compute) { instance_double("Fog::Compute::Base") }
   subject{ Bosh::Bootstrap::MicroboshProviders::Base.new(microbosh_yml, settings, fog_compute ) }
-
 
   context "creates micro_bosh.yml manifest" do
     before { setting "bosh.name", "test-bosh" }
@@ -28,6 +26,29 @@ describe Bosh::Bootstrap::MicroboshProviders::Base do
         subject.create_microbosh_yml(settings)
         expect(File).to be_exists(microbosh_yml)
         yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.without_recursor.yml"))
+      end
+    end
+
+    describe "#ntp_servers" do
+      it "adds ntp when provided as string" do
+        setting "ntp", "0.foo.pool.ntp.org,1.foo.pool.ntp.org"
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.with_ntp.yml"))
+      end
+
+      it "adds ntp when provided as array" do
+        setting "ntp", %w[0.foo.pool.ntp.org 1.foo.pool.ntp.org]
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.with_ntp.yml"))
+      end
+
+      it "adds ntp when setting provided.ntps for backward compatibility" do
+        setting "provider.ntps", %w[0.foo.pool.ntp.org 1.foo.pool.ntp.org]
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.base.with_ntp.yml"))
       end
     end
   end


### PR DESCRIPTION
In this PR all ntp related logic is moved into the base class.
Also it now correctly sets `cloud.properties.agent.ntp` (used for the microbosh vm it self) and `apply_spec.properties.ntp` (for configuring the director, which uses it form the vms it creates).