### PR TITLE
add support for ignore_server_availability_zone in openstack provider

### DIFF
--- a/lib/bosh-bootstrap/microbosh_providers/openstack.rb
+++ b/lib/bosh-bootstrap/microbosh_providers/openstack.rb
@@ -109,7 +109,8 @@ module Bosh::Bootstrap::MicroboshProviders
         "connection_options"=>{
           "ssl_verify_peer"=>false
         },
-        "boot_from_volume"=>boot_from_volume}
+        "boot_from_volume"=>boot_from_volume,
+        "ignore_server_availability_zone"=>ignore_server_availability_zone}
     end
 
     def region
@@ -127,6 +128,10 @@ module Bosh::Bootstrap::MicroboshProviders
 
     def boot_from_volume
       !!(settings.provider["options"] && settings.provider.options.boot_from_volume)
+    end
+
+    def ignore_server_availability_zone
+      !!(settings.provider["options"] && settings.provider.options.ignore_server_availability_zone)
     end
 
     # @return Bosh::Cli::PublicStemcell latest stemcell for openstack/trusty

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.ignore_server_availability_zone.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.ignore_server_availability_zone.yml
@@ -1,0 +1,51 @@
+---
+name: test-bosh
+logging:
+  level: DEBUG
+network:
+  type: manual
+  ip: 10.10.10.3
+  cloud_properties:
+    net_id: 7b8788eb-b49e-4424-9065-75a6b07094ea
+resources:
+  persistent_disk: 32768
+  cloud_properties:
+    instance_type: m1.medium
+cloud:
+  plugin: openstack
+  properties:
+    openstack:
+      auth_url: http://10.0.0.2:5000/v2.0/tokens
+      username: USER
+      api_key: PASSWORD
+      tenant: TENANT
+      region: REGION
+      default_security_groups:
+      - ssh
+      - dns-server
+      - bosh
+      default_key_name: test-bosh
+      state_timeout: 300
+      private_key: ~/.microbosh/ssh/test-bosh
+      connection_options:
+        ssl_verify_peer: false
+      boot_from_volume: false
+      ignore_server_availability_zone: true
+    agent:
+      ntp:
+        - 0.pool.ntp.org
+        - 1.pool.ntp.org
+apply_spec:
+  agent:
+    blobstore:
+      address: 10.10.10.3
+    nats:
+      address: 10.10.10.3
+  properties:
+    director:
+      max_threads: 3
+    hm:
+      resurrector_enabled: true
+    ntp:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org

--- a/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
+++ b/spec/assets/microbosh_yml/micro_bosh.openstack.neutron_manual.yml
@@ -30,6 +30,7 @@ cloud:
       connection_options:
         ssl_verify_peer: false
       boot_from_volume: false
+      ignore_server_availability_zone: false
     agent:
       ntp:
         - 0.pool.ntp.org

--- a/spec/unit/microbosh_providers/openstack_spec.rb
+++ b/spec/unit/microbosh_providers/openstack_spec.rb
@@ -80,6 +80,14 @@ describe Bosh::Bootstrap::MicroboshProviders::OpenStack do
         yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.boot_from_volume.yml"))
       end
 
+      it "ignores server availability zone" do
+        setting "provider.options.ignore_server_availability_zone", true
+
+        subject.create_microbosh_yml(settings)
+        expect(File).to be_exists(microbosh_yml)
+        yaml_files_match(microbosh_yml, spec_asset("microbosh_yml/micro_bosh.openstack.ignore_server_availability_zone.yml"))
+      end
+
       it "adds recursor if present" do
         setting "recursor", "4.5.6.7"
 


### PR DESCRIPTION
`ignore_server_availability_zone` is a standard micro_bosh option and is referred to here: 

https://lists.cloudfoundry.org/archives/list/cf-bosh@lists.cloudfoundry.org/message/UV6YQEV4QL4XW7BIBWO3KOZLM3KHMBW2/

Setting the option in settings.yml does not work as it is not surfaced through bosh-bootstrap to the eventual micro_bosh.yml, this PR addresses that.
