### PR TITLE
Don't lock down httclient

### DIFF
--- a/bosh-bootstrap.gemspec
+++ b/bosh-bootstrap.gemspec
@@ -28,7 +28,7 @@ EOS
   gem.add_dependency "fog-aws"
   gem.add_dependency "readwritesettings", "~> 3.0"
   gem.add_dependency "thor", "~> 0.18"
-  gem.add_dependency "httpclient", '=2.4.0'
+  gem.add_dependency "httpclient"
 
   gem.add_dependency "redcard"
   gem.add_dependency "rbvmomi"


### PR DESCRIPTION
`bosh_cli` as of version 1.3202.0 has already moved up `httpclient` to `2.7.1`.
https://rubygems.org/gems/bosh_cli
