### PR TITLE
Update the version of httpclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 script: bundle exec rake spec:$SUITE
 rvm:
-  - ruby-2.1.3
+  - ruby-2.2.5
 notifications:
   email:
     recipients:

--- a/bosh-bootstrap.gemspec
+++ b/bosh-bootstrap.gemspec
@@ -28,7 +28,7 @@ EOS
   gem.add_dependency "fog-aws"
   gem.add_dependency "readwritesettings", "~> 3.0"
   gem.add_dependency "thor", "~> 0.18"
-  gem.add_dependency "httpclient", '=2.4.0'
+  gem.add_dependency "httpclient", '=2.7.1'
 
   gem.add_dependency "redcard"
   gem.add_dependency "rbvmomi"


### PR DESCRIPTION
This is required to allow using new versions of bosh_cli, et. al
